### PR TITLE
fix: clear words when user logouts

### DIFF
--- a/lib/pages/words/words_page.dart
+++ b/lib/pages/words/words_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../constants/colors.dart';
@@ -62,14 +61,8 @@ class _WordsPageState extends State<WordsPage> {
       _oldLen = newWords.length;
     });
 
-    if (ws.canSkipFetchingWords) {
-      if (kDebugMode) {
-        print('💤 words fetching skipped');
-      }
-      return;
-    }
-
-    WidgetsBinding.instance.addPostFrameCallback((_) => _refreshWordsHandler());
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _refreshWordsHandler(true));
   }
 
   @override
@@ -156,10 +149,10 @@ class _WordsPageState extends State<WordsPage> {
     );
   }
 
-  Future<void> _refreshWordsHandler() {
+  Future<void> _refreshWordsHandler([bool canSkipRefetching = false]) {
     String? uid = AuthInfo.of(context).appUser?.uid;
     final ws = WordsService();
-    return ws.fetchWords(uid);
+    return ws.fetchWords(uid, canSkipRefetching);
   }
 }
 

--- a/lib/widgets/app_drawer_content.dart
+++ b/lib/widgets/app_drawer_content.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../constants/colors.dart';
 import '../services/auth_service.dart';
+import '../services/words_service.dart';
 import 'inherited/auth_state.dart';
 import 'ui/fading_separator.dart';
 
@@ -65,6 +66,8 @@ class AppDrawerContent extends StatelessWidget {
               child: TextButton(
                 child: const Text('LOGOUT'),
                 onPressed: () {
+                  final ws = WordsService();
+                  ws.clear();
                   final authService = AuthService();
                   authService.logout();
                 },


### PR DESCRIPTION
- clear part of the words service's state when on user logout;
- check is refetching words should be skipped inside fetch method instead of words page widget;
- remove unnecessary variables from the words service;